### PR TITLE
feat: allow to filter the crawling

### DIFF
--- a/crawl.html
+++ b/crawl.html
@@ -50,6 +50,9 @@
 
                                         <sp-field-label for="crawl-sitemap-file" required>Sitemap</sp-field-label>
                                         <sp-textfield class="option-field" id="crawl-sitemap-file" value="/sitemap.xml"></sp-textfield>
+
+                                        <sp-field-label for="crawl-filter-pathname" required>Filter pathname</sp-field-label>
+                                        <sp-textfield class="option-field" id="crawl-filter-pathname" value="/"></sp-textfield>
                                     </div>
                                 </sp-accordion-item>
                             </sp-accordion>

--- a/js/crawl/crawl.ui.js
+++ b/js/crawl/crawl.ui.js
@@ -121,6 +121,9 @@ const attachListeners = () => {
     const processNext = () => {
       if (urlsArray.length > 0) {
         const url = urlsArray.pop();
+
+        console.log('Crawling', url);
+
         const { proxy } = getProxyURLSetup(url, config.origin);
         const src = proxy.url;
 
@@ -155,7 +158,10 @@ const attachListeners = () => {
                     const extension = u.pathname.split('.').pop();
                     if (IGNORED_EXTENSIONS.indexOf(extension) === -1) {
                       // eslint-disable-next-line max-len
-                      if (!crawlStatus.urls.includes(found) && !urlsArray.includes(found) && current !== found) {
+                      if (!crawlStatus.urls.includes(found) && 
+                        !urlsArray.includes(found) &&
+                        current !== found &&
+                        u.pathname.startsWith(config.fields['crawl-filter-pathname'])) {
                         urlsArray.push(found);
                         linksToFollow.push(found);
                       } else {
@@ -288,9 +294,12 @@ const attachListeners = () => {
     crawlStatus.hasExtra = false;
 
     // eslint-disable-next-line no-alert
-    crawlStatus.urls = await loadURLsFromRobots(config.origin, URLS_INPUT.value, {
+    crawlStatus.urls = (await loadURLsFromRobots(config.origin, URLS_INPUT.value, {
       log: alert.success,
       sitemap: config.fields['crawl-sitemap-file'],
+    })).filter((url) => {
+      const u = new URL(url);
+      return u.pathname.startsWith(config.fields['crawl-filter-pathname'])
     });
 
     crawlStatus.crawled = crawlStatus.urls.length;

--- a/js/crawl/crawl.ui.js
+++ b/js/crawl/crawl.ui.js
@@ -122,8 +122,6 @@ const attachListeners = () => {
       if (urlsArray.length > 0) {
         const url = urlsArray.pop();
 
-        console.log('Crawling', url);
-
         const { proxy } = getProxyURLSetup(url, config.origin);
         const src = proxy.url;
 


### PR DESCRIPTION
Some sites are sub-sites on a given host. It might be interesting to only crawl a given sub-site and not go through the full host.

Note that there is a difference between the 2 actions:
- `Get from robots.txt or sitemap` processes all sitemaps and then filter the urls
- ` Crawl` only crawl the next page if the filter matches. A page only accessible from the parent host would not be found. 