### PR TITLE
feat: scroll to bottom

### DIFF
--- a/import-bulk.html
+++ b/import-bulk.html
@@ -56,6 +56,10 @@
                                         <sp-checkbox class="option-field" id="import-show-preview" checked>
                                             Show preview
                                         </sp-checkbox>
+
+                                        <sp-checkbox class="option-field" id="import-scroll-to-bottom" checked>
+                                            Scroll to bottom
+                                        </sp-checkbox>
                                     </div>
                                 </sp-accordion-item>
                             </sp-accordion>

--- a/import.html
+++ b/import.html
@@ -60,6 +60,10 @@
                                         <sp-checkbox class="option-field" id="import-enable-js" checked>
                                             Enable JavaScript
                                         </sp-checkbox>
+
+                                        <sp-checkbox class="option-field" id="import-scroll-to-bottom" checked>
+                                            Scroll to bottom
+                                        </sp-checkbox>
                                     </div>
                                 </sp-accordion-item>
                             </sp-accordion>

--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -292,6 +292,10 @@ const attachListeners = () => {
               const onLoad = async () => {
                 const includeDocx = !!dirHandle;
 
+                if (config.fields['import-scroll-to-bottom']) {
+                  frame.contentWindow.window.scrollTo({ left: 0, top: frame.contentDocument.body.scrollHeight, behavior: "smooth" });
+                }
+
                 window.setTimeout(async () => {
                   const { originalURL, replacedURL } = frame.dataset;
                   if (frame.contentDocument) {


### PR DESCRIPTION
Scroll to bottom in the preview frame. This can be useful if images are loaded eager or even via Javascript. The scroll happens before the page load timeout which allows to tweak the time to wait before executing the import script (give time to images to be downloaded).