### PR TITLE
fix: do not ignore query parameters

### DIFF
--- a/js/shared/sitemap.js
+++ b/js/shared/sitemap.js
@@ -25,7 +25,7 @@ async function loadSitemap(sitemapURL, origin, host, config = {}) {
     let urls = [];
     const promises = subSitemaps.map((loc) => new Promise((resolve) => {
       const subSitemapURL = new URL(loc.textContent, origin);
-      loadSitemap(subSitemapURL.pathname, origin, host, config).then((result) => {
+      loadSitemap(subSitemapURL.toString(), origin, host, config).then((result) => {
         urls = urls.concat(result);
         resolve(true);
       });


### PR DESCRIPTION
Try to crawl urls from sitemap on site: https://www.eder-gmbh.de/
This crashes the browser.

Root cause: infinite loop.
Explanation: sitemap.xml file contains 2 references:
- https://www.eder-gmbh.de/sitemap.xml?sitemap=pages&amp;cHash=219806291a8377c2a5347573b5d50f24
- https://www.eder-gmbh.de/sitemap.xml?sitemap=news&amp;cHash=d8277f1d000b07961fe1367319dbb1b4

The query parameters are ignored thus infinite loop...


