### PR TITLE
feat: document how to collect site data without creating docx files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "helix-import-ui",
       "version": "1.20.0",
       "dependencies": {
-        "@adobe/helix-importer": "2.4.1",
+        "@adobe/helix-importer": "2.5.0",
         "@adobe/mdast-util-gridtables": "1.0.3",
         "@adobe/remark-gridtables": "1.0.0",
         "@spectrum-web-components/bundle": "0.28.5",
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@adobe/helix-importer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-importer/-/helix-importer-2.4.1.tgz",
-      "integrity": "sha512-aA+2xm7cHvmesnaDwJavoUX4GB6xv5lcFAa79Pe/9NVChTn23+QAX8cDz9McJRmSZ09Ui2Eimjj7e4FMppJqCA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-importer/-/helix-importer-2.5.0.tgz",
+      "integrity": "sha512-gC5PfllGHlLiHxVYMVuNqCA9Q5zyvIlR/GdSEsuvjxrtz9Fsky7/wl5Nr0OeLEClo8P/aRx6+ZmVUuekQ8hEnw==",
       "dependencies": {
         "@adobe/helix-markdown-support": "6.0.0",
         "@adobe/helix-md2docx": "2.0.28",
@@ -18333,9 +18333,9 @@
       }
     },
     "@adobe/helix-importer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-importer/-/helix-importer-2.4.1.tgz",
-      "integrity": "sha512-aA+2xm7cHvmesnaDwJavoUX4GB6xv5lcFAa79Pe/9NVChTn23+QAX8cDz9McJRmSZ09Ui2Eimjj7e4FMppJqCA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-importer/-/helix-importer-2.5.0.tgz",
+      "integrity": "sha512-gC5PfllGHlLiHxVYMVuNqCA9Q5zyvIlR/GdSEsuvjxrtz9Fsky7/wl5Nr0OeLEClo8P/aRx6+ZmVUuekQ8hEnw==",
       "requires": {
         "@adobe/helix-markdown-support": "6.0.0",
         "@adobe/helix-md2docx": "2.0.28",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
-    "@adobe/helix-importer": "2.4.1",
+    "@adobe/helix-importer": "2.5.0",
     "@adobe/mdast-util-gridtables": "1.0.3",
     "@adobe/remark-gridtables": "1.0.0",
     "@spectrum-web-components/bundle": "0.28.5",


### PR DESCRIPTION
By using the reporting capability and omitting the `element` property of the `transform` returned object, you can skip the `docx` files creation and only feed the report `xlsx` with data.