### PR TITLE
Refactor scroll flow to better handle lazy loading

### DIFF
--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -221,23 +221,24 @@ const createImporter = () => {
 
 const getContentFrame = () => document.querySelector(`${PARENT_SELECTOR} iframe`);
 
-const sleep = (ms) => {
-  return new Promise(
-    (resolve) => {
-      setTimeout(resolve, ms);
-    },
-  );
-};
+const sleep = (ms) => new Promise(
+  (resolve) => {
+    setTimeout(resolve, ms);
+  },
+);
 
 const smartScroll = async (window) => {
   let scrolledOffset = 0;
-  while (window.document.body.scrollHeight > scrolledOffset) {
+  let maxLoops = 4;
+  while (maxLoops > 0 && window.document.body.scrollHeight > scrolledOffset) {
     const scrollTo = window.document.body.scrollHeight;
     window.scrollTo({ left: 0, top: scrollTo, behavior: 'smooth' });
     scrolledOffset = scrollTo;
+    maxLoops -= 1;
+    // eslint-disable-next-line no-await-in-loop
     await sleep(250);
   }
-}
+};
 
 const attachListeners = () => {
   attachOptionFieldsListeners(config.fields, PARENT_SELECTOR);

--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -221,6 +221,24 @@ const createImporter = () => {
 
 const getContentFrame = () => document.querySelector(`${PARENT_SELECTOR} iframe`);
 
+const sleep = (ms) => {
+  return new Promise(
+    (resolve) => {
+      setTimeout(resolve, ms);
+    },
+  );
+};
+
+const smartScroll = async (window) => {
+  let scrolledOffset = 0;
+  while (window.document.body.scrollHeight > scrolledOffset) {
+    const scrollTo = window.document.body.scrollHeight;
+    window.scrollTo({ left: 0, top: scrollTo, behavior: 'smooth' });
+    scrolledOffset = scrollTo;
+    await sleep(250);
+  }
+}
+
 const attachListeners = () => {
   attachOptionFieldsListeners(config.fields, PARENT_SELECTOR);
 
@@ -327,24 +345,28 @@ const attachListeners = () => {
                 const includeDocx = !!dirHandle;
 
                 if (config.fields['import-scroll-to-bottom']) {
-                  frame.contentWindow.window.scrollTo({ left: 0, top: frame.contentDocument.body.scrollHeight, behavior: 'smooth' });
+                  await smartScroll(frame.contentWindow.window);
                 }
 
-                window.setTimeout(async () => {
-                  const { originalURL, replacedURL } = frame.dataset;
-                  if (frame.contentDocument) {
-                    config.importer.setTransformationInput({
-                      url: replacedURL,
-                      document: frame.contentDocument,
-                      includeDocx,
-                      params: { originalURL },
-                    });
-                    await config.importer.transform();
-                  }
+                await sleep(config.fields['import-pageload-timeout'] || 100);
 
-                  const event = new Event('transformation-complete');
-                  frame.dispatchEvent(event);
-                }, config.fields['import-pageload-timeout'] || 100);
+                if (config.fields['import-scroll-to-bottom']) {
+                  await smartScroll(frame.contentWindow.window);
+                }
+
+                const { originalURL, replacedURL } = frame.dataset;
+                if (frame.contentDocument) {
+                  config.importer.setTransformationInput({
+                    url: replacedURL,
+                    document: frame.contentDocument,
+                    includeDocx,
+                    params: { originalURL },
+                  });
+                  await config.importer.transform();
+                }
+
+                const event = new Event('transformation-complete');
+                frame.dispatchEvent(event);
               };
 
               frame.addEventListener('load', onLoad);


### PR DESCRIPTION
Simpler implementation than what we discussed yesterday but it's also a simpler one. The idea is to re-use the "Page Load Timeout".

### New scroll flow:
1. (if enabled) Scroll right after page load to trigger potential lazy loading
2. (if enabled) wait "Page Load Timeout" time
3. (if enabled) Scroll once more in case lazy loading took some time to finish

### "Smart" scroll function:
1. scroll to bottom
2. wait 250ms
3. check if main scrollHeight increase:
   1. If yes => 1.
   2. If no => stop!

### Test

* URL: https://www.adobe.com/products/substance3d-modeler.html
* min "Page Load Timeout": 1s.
* Enable "Scroll to bottom"

Decrease "Page Load Timeout" to check that lazy loading is not imported.