### PR TITLE
Make import result header stick to top when scrolling list

### DIFF
--- a/css/import/import.css
+++ b/css/import/import.css
@@ -173,8 +173,8 @@
   width: 100%;
 }
 
-.import #import-result {
-  height: calc(100vh - 212px);
+.import #import-result ul {
+  height: calc(100vh - 250px);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
I find this improvement even more meaningful since addition of elapsed time.

Screenshot:
![Screenshot 2023-02-02 at 11 15 21](https://user-images.githubusercontent.com/40354404/216297162-753f4c66-fc7c-4b08-8344-a4214f3ce337.png)
