### PR TITLE
feat: prepend [importer-ui] to be able to filter logs

### DIFF
--- a/crawl.html
+++ b/crawl.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="./css/styles.css" />
     <link rel="stylesheet" href="./css/crawl/crawl.css" />
 
+    <script src="./js/shared/log.js"></script>
     <script src="./js/dist/spectrum-web-components.js"></script>
 
     <script src="./js/libs/vendors/exceljs/exceljs.min.js"></script>

--- a/import-bulk.html
+++ b/import-bulk.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="./css/styles.css" />
     <link rel="stylesheet" href="./css/import/import.css" />
 
+    <script src="./js/shared/log.js"></script>
     <script src="./js/dist/spectrum-web-components.js"></script>
 
     <script src="./js/libs/vendors/babel-polyfill/polyfill.js"></script>

--- a/import.html
+++ b/import.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="./css/styles.css" />
     <link rel="stylesheet" href="./css/import/import.css" />
 
+    <script src="./js/shared/log.js"></script>
     <script src="./js/dist/spectrum-web-components.js"></script>
 
     <script src="./js/libs/vendors/codemirror/codemirror.js"></script>

--- a/inspect.html
+++ b/inspect.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="./css/styles.css" />
     <link rel="stylesheet" href="./css/inspect/inspect.css" />
 
+    <script src="./js/shared/log.js"></script>
     <script src="./js/dist/spectrum-web-components.js"></script>
 
     <script src="./js/inspect/inspect.ui.js" type="module"></script>

--- a/js/shared/log.js
+++ b/js/shared/log.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-disable no-underscore-dangle, no-console */
+{
+  const patchArgs = (args) => {
+    if (typeof args[0] === 'string') {
+      args[0] = `[importer-ui] ${args[0]}`;
+    }
+  };
+
+  const _log = console.log;
+  console.log = (...args) => {
+    patchArgs(args);
+    _log(...args);
+  };
+
+  const _warn = console.warn;
+  console.warn = (...args) => {
+    patchArgs(args);
+    _warn(...args);
+  };
+
+  const _error = console.error;
+  console.error = (...args) => {
+    patchArgs(args);
+    _error(...args);
+  };
+}


### PR DESCRIPTION
Some imported pages flood the console with lots of errors, warnings or even logs. It is hard to extract the info from the importer. By prepending all console.log with a marker (chosen one so far `[importer-ui]`), we can filter out all the rest and views what is going on during the import process.