### PR TITLE
feat: add optional custom headers field

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ In the `URL(s)` field, give a list of page URLs to be imported (e.g. {https://ww
   - if the remote page is an SPA (React, Angular) or require Javascript to load some pieces of the content, Javascript is then required. Enabling Javascript may help here.
   - more generally, disabling Javascript speeds up the import process and reduces the memory consumed.
 - `Scroll to bottom`: forces a scroll to the bottom of the page. This might allow images set with earger to be loaded or any element loaded with Javascript below the fold. Increasing the `Page load timeout` might give more time to those element to be loaded.
+- `Custom headers`: connection to the site you want to import content from might require some custom request headers, like a Bear, an API key (especially when hitting JSON API), a Coookie... Those headers are sent together with the fetch request (headers config property of the standard browser `fetch` API).
 
 ## Crawler
 

--- a/import-bulk.html
+++ b/import-bulk.html
@@ -61,6 +61,9 @@
                                         <sp-checkbox class="option-field" id="import-scroll-to-bottom" checked>
                                             Scroll to bottom
                                         </sp-checkbox>
+
+                                        <sp-field-label for="import-custom-headers">Custom headers</sp-field-label>
+                                        <sp-textfield class="option-field" id="import-custom-headers" multiline placeholder="Define your custom headers as a JSON object with key/value (header name/header value)"></sp-textfield>
                                     </div>
                                 </sp-accordion-item>
                             </sp-accordion>

--- a/import.html
+++ b/import.html
@@ -64,6 +64,9 @@
                                         <sp-checkbox class="option-field" id="import-scroll-to-bottom" checked>
                                             Scroll to bottom
                                         </sp-checkbox>
+
+                                        <sp-field-label for="import-custom-headers">Custom headers</sp-field-label>
+                                        <sp-textfield class="option-field" id="import-custom-headers" multiline placeholder="Define your custom headers as a JSON object with key/value (header name/header value)"></sp-textfield>
                                     </div>
                                 </sp-accordion-item>
                             </sp-accordion>

--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -419,10 +419,13 @@ const attachListeners = () => {
 
         let res;
         try {
-          res = await fetch(src);
+          const headers = JSON.parse(config.fields['import-custom-headers'] || '{}');
+          res = await fetch(src, {
+            headers,
+          });
         } catch (e) {
           // eslint-disable-next-line no-console
-          console.error(`Unexpected error when trying to fetch ${src} - CORS issue ?`, e);
+          console.error(`Unexpected error when trying to fetch ${src} - CORS issue or invalid headers ?`, e);
         }
         if (res && res.ok) {
           if (res.redirected) {
@@ -494,7 +497,8 @@ const attachListeners = () => {
 
               frame.dataset.originalURL = url;
               frame.dataset.replacedURL = src;
-              frame.src = src;
+
+              frame.src = URL.createObjectURL(await res.blob());
 
               const current = getContentFrame();
               current.removeEventListener('load', onLoad);


### PR DESCRIPTION
Having the capability to provide custom headers to the request made to fetch the remote server content might be required: for certain JSON API request, we need to pass an header token.