### PR TITLE
fix: use proxied url as content base

### DIFF
--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -503,7 +503,7 @@ const attachListeners = () => {
                 blob = await res.blob();
               } else {
                 let html = await res.text();
-                html = html.replace(/<head>/, `<head><base href="${remote.origin}">`);
+                html = html.replace(/<head>/, `<head><base href="${src}">`);
                 blob = new Blob([html], { type: 'text/html' });
               }
 


### PR DESCRIPTION
#150 introduced an issue: the content frame now loaded via the remote url, which means the proxy is by-passed, thus re-introducing CSP issues.