### PR TITLE
fix: use original document to re-run import process

### DIFF
--- a/js/shared/pollimporter.js
+++ b/js/shared/pollimporter.js
@@ -116,7 +116,7 @@ export default class PollImporter {
       if (includeDocx) {
         const out = await WebImporter.html2docx(
           url,
-          document,
+          document.cloneNode(true),
           this.projectTransform,
           params,
         );
@@ -129,7 +129,7 @@ export default class PollImporter {
       } else {
         const out = await WebImporter.html2md(
           url,
-          document,
+          document.cloneNode(true),
           this.projectTransform,
           params,
         );


### PR DESCRIPTION
Fix #171 

`preprocess` is re-executed. The problem is that it operates on a document which has been modified previously. In the case of JSON imports, the document does not contain the JSON object but the generated DOM.

I wonder why this has not been an issue before, the document `preprocess` and `transform` operate on is the latest transformed one, i.e. if you run multiple time the transformations... ?