### PR TITLE
[crawl] Fix non html URLs

### DIFF
--- a/js/crawl/crawl.ui.js
+++ b/js/crawl/crawl.ui.js
@@ -36,6 +36,21 @@ const IGNORED_EXTENSIONS = [
   'webp',
   'eps',
   'pdf',
+  'doc',
+  'docx',
+  'xls',
+  'xlsx',
+  'ppt',
+  'pptx',
+  'zip',
+  'gz',
+  'tgz',
+  'tar',
+  'bz2',
+  'dmg',
+  'exe',
+  'iso',
+  'mp4',
 ];
 
 const config = {};

--- a/js/crawl/crawl.ui.js
+++ b/js/crawl/crawl.ui.js
@@ -171,6 +171,7 @@ const attachListeners = () => {
               let nbLinksExternalHost = 0;
               let nbLinksAlreadyProcessed = 0;
               const linksToFollow = [];
+              const linksExcluded = [];
               links.forEach((a) => {
                 nbLinks += 1;
                 if (a.href) {
@@ -190,6 +191,8 @@ const attachListeners = () => {
                       } else {
                         nbLinksAlreadyProcessed += 1;
                       }
+                    } else {
+                      linksExcluded.push(found);
                     }
                   } else {
                     nbLinksExternalHost += 1;
@@ -206,6 +209,8 @@ const attachListeners = () => {
                 nbLinksExternalHost,
                 nbLinksToFollow: linksToFollow.length,
                 linksToFollow,
+                nbLinksExcluded: linksExcluded.length,
+                linksExcluded,
               };
               crawlStatus.rows.push(row);
               crawlStatus.crawled += 1;
@@ -280,7 +285,7 @@ const attachListeners = () => {
 
     let headers = ['URL'];
     if (crawlStatus.hasExtra) {
-      headers = ['URL', 'status', 'redirect', 'Nb links on page', 'Nb links already processed', 'Nb links on external host', 'Nb links to follow', 'Links to follow'];
+      headers = ['URL', 'status', 'redirect', 'Nb links on page', 'Nb links already processed', 'Nb links on external host', 'Nb links to follow', 'Links to follow', 'Nb links excluded', 'Links excluded'];
       worksheet.autoFilter = {
         from: 'A1',
         to: 'H1',
@@ -304,10 +309,12 @@ const attachListeners = () => {
       nbLinksExternalHost,
       nbLinksToFollow,
       linksToFollow,
+      nbLinksExcluded,
+      linksExcluded,
     }) => {
       if (crawlStatus.hasExtra) {
         return [
-          url, status, redirect || '', nbLinks || '', nbLinksAlreadyProcessed || '', nbLinksExternalHost || '', nbLinksToFollow || '', linksToFollow ? linksToFollow.join(', ') : '',
+          url, status, redirect || '', nbLinks || '', nbLinksAlreadyProcessed || '', nbLinksExternalHost || '', nbLinksToFollow || '', linksToFollow ? linksToFollow.join(', ') : '', nbLinksExcluded || '', linksExcluded ? linksExcluded.join(', ') : '',
         ];
       }
       return [url];

--- a/js/crawl/crawl.ui.js
+++ b/js/crawl/crawl.ui.js
@@ -149,11 +149,11 @@ const attachListeners = () => {
         const frame = document.createElement('iframe');
         frame.id = 'crawl-content-frame';
 
+        let sandboxAttr = 'allow-same-origin';
         if (config.fields['crawl-enable-js']) {
-          frame.removeAttribute('sandbox');
-        } else {
-          frame.setAttribute('sandbox', 'allow-same-origin');
+          sandboxAttr += ' allow-scripts';
         }
+        frame.setAttribute('sandbox', sandboxAttr);
 
         const onLoad = async () => {
           if (config.fields['import-scroll-to-bottom']) {


### PR DESCRIPTION
Fixes #190 

What it does:
1. Add common extensions to the exclusion list
2. Denies automated download in the crawl iframe to trigger standard warning notification in web console to help inform the user about an unsupported extension that is breaking the crawling flow.
3. Add reporting about excluded URLs

About 2., I could not catch the "download" event in the iframe so I cannot generate an alert ribbon in the application UI so the only notification is the standard one in the web console.