### PR TITLE
fix: crawl silently failing on sitemap parsing errors

### DIFF
--- a/js/crawl/crawl.ui.js
+++ b/js/crawl/crawl.ui.js
@@ -99,7 +99,7 @@ const enableProcessButtons = () => {
 };
 
 const resetResultPanelHeader = () => {
-  if(CRAWLED_URLS_LIST.childNodes.length === 0) {
+  if (CRAWLED_URLS_LIST.childNodes.length === 0) {
     CRAWLED_URLS_HEADING.innerText = '';
   }
 };
@@ -352,7 +352,7 @@ const attachListeners = () => {
         const u = new URL(url);
         return u.pathname.startsWith(config.fields['crawl-filter-pathname']);
       });
-  
+
       crawlStatus.crawled = crawlStatus.urls.length;
       crawlStatus.urls.forEach((url, index) => {
         if (index === 1000) {
@@ -360,13 +360,13 @@ const attachListeners = () => {
         } else if (index < 1000) {
           displayCrawledURL(url);
         }
-  
+
         const row = {
           url,
         };
         crawlStatus.rows.push(row);
       });
-    } catch(e) {
+    } catch (e) {
       alert.error(`Error while loading sitemaps and URLs from robots.txt: ${e}`);
     }
 

--- a/js/shared/sitemap.js
+++ b/js/shared/sitemap.js
@@ -22,7 +22,7 @@ async function loadSitemap(sitemapURL, origin, host, config = {}) {
     const xml = (await resp.text()).trim();
     const sitemap = (new window.DOMParser()).parseFromString(xml, 'text/xml');
 
-    const errorNode = sitemap.querySelector("parsererror");
+    const errorNode = sitemap.querySelector('parsererror');
     if (errorNode) {
       // parsing failed
       throw new Error(`parsing sitemap ${sitemapURL}: ${errorNode.textContent}`);
@@ -36,15 +36,15 @@ async function loadSitemap(sitemapURL, origin, host, config = {}) {
           resolve(true);
         });
       }));
-  
+
       await Promise.all(promises);
-  
+
       const urlLocs = sitemap.querySelectorAll('url loc');
       urlLocs.forEach((loc) => {
         const u = new URL(loc.textContent, host);
         urls.push(u.toString());
       });
-  
+
       return urls;
     }
   }

--- a/js/shared/sitemap.js
+++ b/js/shared/sitemap.js
@@ -19,7 +19,7 @@ async function loadSitemap(sitemapURL, origin, host, config = {}) {
     if (config.log) {
       config.log(`Extracting URLs from sitemap: ${sitemapURL}`);
     }
-    const xml = await resp.text();
+    const xml = (await resp.text()).trim();
     const sitemap = (new window.DOMParser()).parseFromString(xml, 'text/xml');
     const subSitemaps = [...sitemap.querySelectorAll('sitemap loc')];
     let urls = [];

--- a/js/shared/sitemap.js
+++ b/js/shared/sitemap.js
@@ -21,25 +21,32 @@ async function loadSitemap(sitemapURL, origin, host, config = {}) {
     }
     const xml = (await resp.text()).trim();
     const sitemap = (new window.DOMParser()).parseFromString(xml, 'text/xml');
-    const subSitemaps = [...sitemap.querySelectorAll('sitemap loc')];
-    let urls = [];
-    const promises = subSitemaps.map((loc) => new Promise((resolve) => {
-      const subSitemapURL = new URL(loc.textContent, origin);
-      loadSitemap(subSitemapURL.toString(), origin, host, config).then((result) => {
-        urls = urls.concat(result);
-        resolve(true);
+
+    const errorNode = sitemap.querySelector("parsererror");
+    if (errorNode) {
+      // parsing failed
+      throw new Error(`parsing sitemap ${sitemapURL}: ${errorNode.textContent}`);
+    } else {
+      const subSitemaps = [...sitemap.querySelectorAll('sitemap loc')];
+      let urls = [];
+      const promises = subSitemaps.map((loc) => new Promise((resolve) => {
+        const subSitemapURL = new URL(loc.textContent, origin);
+        loadSitemap(subSitemapURL.toString(), origin, host, config).then((result) => {
+          urls = urls.concat(result);
+          resolve(true);
+        });
+      }));
+  
+      await Promise.all(promises);
+  
+      const urlLocs = sitemap.querySelectorAll('url loc');
+      urlLocs.forEach((loc) => {
+        const u = new URL(loc.textContent, host);
+        urls.push(u.toString());
       });
-    }));
-
-    await Promise.all(promises);
-
-    const urlLocs = sitemap.querySelectorAll('url loc');
-    urlLocs.forEach((loc) => {
-      const u = new URL(loc.textContent, host);
-      urls.push(u.toString());
-    });
-
-    return urls;
+  
+      return urls;
+    }
   }
   return [];
 }
@@ -67,14 +74,23 @@ async function loadURLsFromRobots(origin, host, config = {}) {
       sitemaps.push(m[1]);
     }
 
-    const promises = sitemaps.map((sitemap) => new Promise((resolve) => {
+    const promises = sitemaps.map((sitemap) => new Promise((resolve, reject) => {
       loadSitemap(sitemap, origin, host, config).then((u) => {
         urls = urls.concat(u);
         resolve();
-      });
+      }).catch(reject);
     }));
 
-    await Promise.all(promises);
+    const results = await Promise.allSettled(promises);
+    const errors = [];
+    results.forEach((result) => {
+      if (result.status === 'rejected') {
+        errors.push(result.reason.message);
+      }
+    });
+    if (errors.length > 0) {
+      throw new Error(errors.join(' - '));
+    }
   } else {
     // eslint-disable-next-line no-console
     const sitemapFile = config.sitemapFile || '/sitemap.xml';


### PR DESCRIPTION
## Context

fixes #193.


## What it does

* auto fix space issue on sitemap content (https://github.com/adobe/helix-importer-ui/commit/ea4b8b9daaaa9bce80498fd3fd0a596ea65677d2)
* catch sitemap parsing issues and notify user via alert banner in the UI (https://github.com/adobe/helix-importer-ui/commit/7f0f333a7d8f7ccc127c4b705b8fd10be084aa62)


## Test

The fix should be tested on https://www.sunstar-foundation.org/ (as their sitemap https://www.sunstar-foundation.org/sitemap.xml has syntax errors) but this PR includes a small trick to auto fix extra space issues ( commit https://github.com/adobe/helix-importer-ui/commit/ea4b8b9daaaa9bce80498fd3fd0a596ea65677d2).

So in order to test the fix, if you don't have any URL of wrong sitemap, remove the `.trim()` and test on https://www.sunstar-foundation.org/