### PR TITLE
feat: use default sitemap if no sitemap found in robots.txt

### DIFF
--- a/js/shared/sitemap.js
+++ b/js/shared/sitemap.js
@@ -74,6 +74,14 @@ async function loadURLsFromRobots(origin, host, config = {}) {
       sitemaps.push(m[1]);
     }
 
+    if (sitemaps.length === 0) {
+      const sitemapFile = config.sitemapFile || '/sitemap.xml';
+      if (config.log) {
+        config.log(`No sitemaps found in robots.txt - trying ${sitemapFile}`);
+      }
+      sitemaps.push(sitemapFile);
+    }
+
     const promises = sitemaps.map((sitemap) => new Promise((resolve, reject) => {
       loadSitemap(sitemap, origin, host, config).then((u) => {
         urls = urls.concat(u);


### PR DESCRIPTION
Try to crawl from `robots.txt / sitemap` the site: https://www.xeljanz.com/
It finds `robots.txt` and it does to contain a sitemap reference... Ideally, the code falls back to still try `sitemap.xml` (or the one defined in the config).