### PR TITLE
margin fix

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -209,7 +209,6 @@ section form {
 }
 
 section sp-accordion sp-accordion-item {
-  margin-left: -16px;
   border-bottom: 0;
 }
 


### PR DESCRIPTION

## Description

Removed an unnecessary margin-left that was causing the import options to be cut off 

## Related Issue

Fix: #249 

## Motivation and Context

Fixes a bad user experience that is annoying to see and use.

## How Has This Been Tested?

run `hlx up` locally to test the fix

## Screenshots (if appropriate):

**Before:**
![Screenshot 2023-08-29 at 2 14 57 PM](https://github.com/adobe/helix-importer-ui/assets/7074782/3c1e4b9b-4fd5-4b7d-9cab-65b9ba67a589)

**After:**
![Screenshot 2023-08-29 at 2 24 25 PM](https://github.com/adobe/helix-importer-ui/assets/7074782/5d43e57e-b23e-4d9d-936d-b676552fff8d)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
