### PR TITLE
fix: handle pages with no content at their center

### DIFF
--- a/js/inspect/inspect.js
+++ b/js/inspect/inspect.js
@@ -92,7 +92,12 @@ const drop = (document) => {
   // XSS review - no problem here
   div.innerHTML = '<h1>H1</h1><h2>H2</h2><h3></h3><h4></h4><h5></h5><h6></h6><a href="#">Link</a><p>Some text</p>';
 
-  center.parentElement.insertBefore(div, center);
+  if (center.parentElement) {
+    center.parentElement.insertBefore(div, center);
+  } else {
+    // fallback to document body
+    document.body.prepend(div);
+  }
 
   const styles = {};
 

--- a/js/inspect/inspect.js
+++ b/js/inspect/inspect.js
@@ -92,7 +92,7 @@ const drop = (document) => {
   // XSS review - no problem here
   div.innerHTML = '<h1>H1</h1><h2>H2</h2><h3></h3><h4></h4><h5></h5><h6></h6><a href="#">Link</a><p>Some text</p>';
 
-  if (center.parentElement) {
+  if (center && center.parentElement) {
     center.parentElement.insertBefore(div, center);
   } else {
     // fallback to document body


### PR DESCRIPTION
Fixes https://github.com/adobe/helix-importer-ui/issues/281

## Description

When given page does not have content at its center, eyedropper cannot find any DOM element to which adding dummy visual elements (`HX`, `a`, ...).
The fix adds a fallback to document.body when center is null. 

## Related Issue

https://github.com/adobe/helix-importer-ui/issues/281

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested on a local test project

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
