### PR TITLE
#283 Ensure report extra columns are assigned to the correct column in excel

### DIFF
--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -320,6 +320,8 @@ const getReport = async () => {
           } else {
             extra.push(JSON.stringify(report[col]));
           }
+        } else {
+          extra.push('');
         }
       });
     }


### PR DESCRIPTION
## Description

The current behaviour is causing issues when not all reports n a bulk import contain the same fields, meaning that if we have a report with fields a, b, c, and another one with b,c, in the resulting excel sheet the first report will appear correctly, and the second while have b assigned to a, and c assigned to be.

## Related Issue

Fix #283
## Motivation and Context
I'm trying to generate a report that will be used to generate an excel sheet so that it can be queried on the site. This is needed for the excel to be generated correctly.

## How Has This Been Tested?
Tested manually in the revolt tv project (access to the code is limited to contributors, but can share more if need be).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
