### PR TITLE
build(package): fix package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "helix-import-ui",
+  "name": "@adobe/helix-importer-ui",
   "version": "1.49.1",
-  "description": "helix-import-ui",
+  "description": "helix-importer-ui",
   "type": "module",
   "scripts": {
     "test": "c8 mocha",


### PR DESCRIPTION
I noticed the package name in `package.json` is not aligned with the repository
name, so I fixed it. I also added the `@adobe` prefix, should we ever need to
release this to NPM
