### PR TITLE
[Feat] #381 Also consider crawl filter as a regexp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/*
 logs/*
 node_modules/*
 *.map
+/.idea/**

--- a/js/crawl/crawl.ui.js
+++ b/js/crawl/crawl.ui.js
@@ -123,6 +123,26 @@ const getProxyURLSetup = (url, origin) => {
   };
 };
 
+/**
+ * Test whether the given path matches the provided filter.
+ * @param path The path of the website page.
+ * @param filter The filter to test the path against, using 'startsWith' and RegExp's test.
+ * @returns {boolean}
+ */
+const pathnameMatchesFilter = (path, filter) => {
+  try {
+    if (!filter || filter.length === 0 || path.startsWith(filter)) {
+      return true;
+    }
+    return new RegExp(filter).test(path);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(`Could not test path ${path} with provided filter: ${filter}`, e);
+    alert.error(`Could not test path with provided filter: ${filter}`);
+    return false;
+  }
+};
+
 const getContentFrame = () => document.querySelector(`${PARENT_SELECTOR} iframe`);
 
 const attachListeners = () => {
@@ -193,7 +213,7 @@ const attachListeners = () => {
                       if (!crawlStatus.urls.includes(found)
                         && !urlsArray.includes(found)
                         && current !== found
-                        && u.pathname.startsWith(config.fields['crawl-filter-pathname'])) {
+                        && pathnameMatchesFilter(u.pathname, config.fields['crawl-filter-pathname'])) {
                         urlsArray.push(found);
                         linksToFollow.push(found);
                       } else {
@@ -354,7 +374,7 @@ const attachListeners = () => {
         sitemap: config.fields['crawl-sitemap-file'],
       })).filter((url) => {
         const u = new URL(url);
-        return u.pathname.startsWith(config.fields['crawl-filter-pathname']);
+        return pathnameMatchesFilter(u.pathname, config.fields['crawl-filter-pathname']);
       });
 
       crawlStatus.crawled = crawlStatus.urls.length;


### PR DESCRIPTION
## Description
Also evaluate a possible page path with the provided filter as a RegExp (not just startsWith).

Ensure current behavior is not changed.

## Related Issue

#381 (Hubble Homes VIP)

## Motivation and Context

Hubble Homes has a very distinct path for a certain template.  The path ends in "/999".  They'd like to target the import to only work on those pages.

## How Has This Been Tested?

Manually.

## Screenshots (if appropriate):

Nothing changed visually.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.  (I did not find any filter documentation.)
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
