### PR TITLE
[doc] Hot reload imported files

### DIFF
--- a/importer-guidelines.md
+++ b/importer-guidelines.md
@@ -738,3 +738,16 @@ export default {
 ```
 
 Just add the extra styles you need to perform your transformation.
+
+### Hot reload of JS Dependencies
+
+It is common to use multiple files for the import process, usually using `import.js` as the entry.  By default, the UI will only hot reload changes in the "Transformation file URL" specified in the UI (i.e. import.js) and *not* its 'imports' which forces the user to refresh whenever dependencies are changed. To enable hot reload of dependencies, the `esbuild` can be used with the watch option.
+
+- Ensure esbuild is installed and accessible.
+- From the command line, start `esbuild` as follows (varying paths and/or parameters as required):
+  - `esbuild import.js --bundle --outdir=importjs --watch`
+  - This will watch for changes on import.js **and** all its imports, bundling them in the specified `outdir`.
+- In the Importer UI, change the transformation file indicated to the one that is built in the output dir.
+
+Now the UI will load the bundled JS file, which will be automatically built when any changes are made.
+

--- a/importer-guidelines.md
+++ b/importer-guidelines.md
@@ -741,9 +741,9 @@ Just add the extra styles you need to perform your transformation.
 
 ### Hot reload of JS Dependencies
 
-It is common to use multiple files for the import process, usually using `import.js` as the entry.  By default, the UI will only hot reload changes in the "Transformation file URL" specified in the UI (i.e. import.js) and *not* its 'imports' which forces the user to refresh whenever dependencies are changed. To enable hot reload of dependencies, the `esbuild` can be used with the watch option.
+It is common to use multiple files for the import process, usually using `import.js` as the entry.  By default, the UI will only hot reload changes in the "Transformation file URL" specified in the UI (i.e. import.js) and *not* its 'imports' which forces the user to refresh whenever dependencies are changed. To enable hot reload of dependencies, `esbuild` can be used with the watch option.
 
-- Ensure esbuild is installed and accessible.
+- Ensure `esbuild` is installed and accessible.
 - From the command line, start `esbuild` as follows (varying paths and/or parameters as required):
   - `esbuild import.js --bundle --outdir=importjs --watch`
   - This will watch for changes on import.js **and** all its imports, bundling them in the specified `outdir`.


### PR DESCRIPTION
[doc] Hot reload imported files
Issue #267

## Description

Use `esbuild` to bundle the import javascript files which allows the UI to hot load all changed files.

## Related Issue

https://github.com/adobe/helix-importer-ui/issues/267

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Instructions followed locally, and each change of the dependency caused a reload (i.e. the console had the entry `[importer-ui] Loaded importer file: http://localhost:3001/tools/importer/import.js?cf=1724101118347` appear each time)

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
