### PR TITLE
258 Indicate if default transformation file is being used

### DIFF
--- a/css/import/import.css
+++ b/css/import/import.css
@@ -45,6 +45,18 @@
   border: 1px solid var(--spectrum-global-color-gray-100);
 }
 
+.import #import-action-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.import #transformation-file-default {
+  text-align: right;
+  font-style: italic;
+  font-size: 12px;
+}
+
 .import sp-theme[color="light"] {
   width: 100%;
   background-color: var(--spectrum-global-color-gray-50);

--- a/import-bulk.html
+++ b/import-bulk.html
@@ -79,9 +79,12 @@
                                 </sp-accordion-item>
                             </sp-accordion>
 
-                            <sp-button-group>
-                                <sp-button id="import-doimport-button">Import</sp-button>
-                            </sp-button-group>
+                            <div id="import-action-row">
+                                <sp-button-group>
+                                    <sp-button id="import-doimport-button">Import</sp-button>
+                                </sp-button-group>
+                                <p id="transformation-file-default" class="hidden">NOTE: The default transformation file is being used.</p>
+                            </div>
                         </form>
                         <span id="folder-name"></span>
                         <div class="page-preview hidden">

--- a/import.html
+++ b/import.html
@@ -82,9 +82,12 @@
                                 </sp-accordion-item>
                             </sp-accordion>
 
-                            <sp-button-group>
-                                <sp-button id="import-doimport-button">Import</sp-button>
-                            </sp-button-group>
+                            <div id="import-action-row">
+                                <sp-button-group>
+                                    <sp-button id="import-doimport-button">Import</sp-button>
+                                </sp-button-group>
+                                <p id="transformation-file-default" class="hidden">NOTE: The default transformation file is being used.</p>
+                            </div>
                         </form>
                         <span id="folder-name"></span>
                         <div class="page-preview hidden">

--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -24,6 +24,7 @@ const PREVIEW_CONTAINER = document.querySelector(`${PARENT_SELECTOR} .page-previ
 
 const IMPORTFILEURL_FIELD = document.getElementById('import-file-url');
 const IMPORT_BUTTON = document.getElementById('import-doimport-button');
+const DEFAULT_TRANSFORMER_USED = document.getElementById('transformation-file-default');
 
 // const SAVEASWORD_BUTTON = document.getElementById('saveAsWord');
 const FOLDERNAME_SPAN = document.getElementById('folder-name');
@@ -396,6 +397,14 @@ const smartScroll = async (window) => {
   }
 };
 
+const setDefaultTransformerNotice = (importer) => {
+  if (importer.usingDefaultTransformer) {
+    DEFAULT_TRANSFORMER_USED.classList.remove('hidden');
+  } else {
+    DEFAULT_TRANSFORMER_USED.classList.add('hidden');
+  }
+};
+
 const attachListeners = () => {
   attachOptionFieldsListeners(config.fields, PARENT_SELECTOR);
 
@@ -433,6 +442,7 @@ const attachListeners = () => {
 
   IMPORT_BUTTON.addEventListener('click', (async () => {
     initImportStatus();
+    setDefaultTransformerNotice(config.importer);
 
     if (IS_BULK) {
       clearResultPanel();
@@ -611,6 +621,7 @@ const attachListeners = () => {
   IMPORTFILEURL_FIELD.addEventListener('change', async (event) => {
     if (config.importer) {
       await config.importer.setImportFileURL(event.target.value);
+      setDefaultTransformerNotice(config.importer);
     }
   });
 

--- a/js/shared/pollimporter.js
+++ b/js/shared/pollimporter.js
@@ -52,6 +52,7 @@ export default class PollImporter {
     this.projectTransform = null;
     this.projectTransformFileURL = '';
     this.running = false;
+    this.usingDefaultTransformer = true;
 
     this.#init();
   }
@@ -71,6 +72,7 @@ export default class PollImporter {
       const res = await fetch(projectTransformFileURL);
       body = await res.text();
 
+      this.usingDefaultTransformer = !res.ok;
       if (res.ok && body !== this.lastProjectTransformFileBody) {
         this.lastProjectTransformFileBody = body;
         await loadModule(projectTransformFileURL);


### PR DESCRIPTION
## Description
A non-existent transformation file is allows, as the default one will then be used, but if a non-existent one is used by accident, it causes confusion for the user, since they think their import script is broken.

If the default transformation file is being used, give the user a subtle note about it is happening.

## Related Issue
#258 

## Motivation and Context
Small note to avoid confusion.

## How Has This Been Tested?

Tested locally, doing imports with the existing files, non-existing files and plain old strangely spelled files.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/9fe7e8b6-99b9-4240-a0e9-b6e27516dc42)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

@kptdobe  For your consideration...
