### PR TITLE
feat: split sections and convert table to divs

### DIFF
--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -107,7 +107,7 @@ const postSuccessfulStep = async (results, originalURL) => {
       }
 
       if (config.fields['import-local-da'] && md) {
-        files.push({ type: 'da', filename: `${path}.html`, data: `<html><head></head><body><main>${WebImporter.md2html(md)}</main></body></html>` });
+        files.push({ type: 'da', filename: `${path}.html`, data: `<body><main>${WebImporter.md2html(md, true)}</main></body>` });
       }
 
       // if we were told to save the JCR package, add it to the list

--- a/modules/md2html.js
+++ b/modules/md2html.js
@@ -14,13 +14,136 @@ import { toHast as mdast2hast, defaultHandlers } from 'mdast-util-to-hast';
 import { raw } from 'hast-util-raw';
 import remarkGridTable from '@adobe/remark-gridtables';
 import { mdast2hastGridTablesHandler, TYPE_TABLE } from '@adobe/mdast-util-gridtables';
+import { h } from 'hastscript';
 import { toHtml } from 'hast-util-to-html';
+import { select } from 'hast-util-select';
+import { toString } from 'hast-util-to-string';
+import { CONTINUE, SKIP, visit } from 'unist-util-visit';
 import rehypeFormat from 'rehype-format';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
 
-export default function md2html(md) {
+/* start: copied from helix-html-pipeline */
+function childNodes(node) {
+  return node.children.filter((n) => n.type === 'element');
+}
+
+function toBlockCSSClassNames(text) {
+  if (!text) {
+    return [];
+  }
+  const names = [];
+  const idx = text.lastIndexOf('(');
+  if (idx >= 0) {
+    names.push(text.substring(0, idx));
+    names.push(...text.substring(idx + 1).split(','));
+  } else {
+    names.push(text);
+  }
+
+  return names.map((name) => name
+    .toLowerCase()
+    .replace(/[^0-9a-z]+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, ''))
+    .filter((name) => !!name);
+}
+
+function tableToDivs($table, wrap = false) {
+  const $cards = h('div');
+  const $rows = [];
+  // eslint-disable-next-line no-restricted-syntax
+  for (const child of $table.children) {
+    if (child.tagName === 'thead' || child.tagName === 'tbody') {
+      $rows.push(...childNodes(child));
+    }
+  }
+
+  if ($rows.length === 0) {
+    return $cards;
+  }
+  const $headerCols = childNodes($rows.shift());
+  if ($headerCols.length === 0) {
+    return $cards;
+  }
+
+  // special case, only 1 row and 1 column with a nested table
+  if ($rows.length === 0 && $headerCols.length === 1) {
+    const $nestedTable = select(':scope table', $headerCols[0]);
+    if ($nestedTable) {
+      return $nestedTable;
+    }
+  }
+
+  // get columns names
+  $cards.properties.className = toBlockCSSClassNames(toString($headerCols[0]));
+  if ($cards.properties.className.length === 0) {
+    delete $cards.properties.className;
+  }
+
+  // construct page block
+  // eslint-disable-next-line no-restricted-syntax
+  for (const $row of $rows) {
+    const $card = h('div');
+    // eslint-disable-next-line no-restricted-syntax
+    for (const $cell of childNodes($row)) {
+      // convert to div
+      $card.children.push(h('div', {
+        'data-align': $cell.properties.align,
+        'data-valign': $cell.properties.vAlign,
+      }, $cell.children));
+    }
+    $cards.children.push($card);
+  }
+
+  if (wrap) {
+    return h('div', {}, $cards);
+  }
+  return $cards;
+}
+
+function createPageBlocks({ content }) {
+  const { hast } = content;
+  visit(hast, (node, idx, parent) => {
+    if (node.tagName === 'table') {
+      parent.children[idx] = tableToDivs(node, parent.tagName !== 'div');
+      return SKIP;
+    }
+    return CONTINUE;
+  });
+}
+
+function split(state) {
+  const { content: { mdast } } = state;
+
+  // filter all children that are break blocks
+  const dividers = mdast.children.filter((node) => node.type === 'thematicBreak')
+    // then get their index in the list of children
+    .map((node) => mdast.children.indexOf(node));
+
+  // find pairwise permutations of spaces between blocks
+  // include the very start and end of the document
+  const starts = [0, ...dividers];
+  const ends = [...dividers, mdast.children.length];
+
+  // content.mdast.children = _.zip(starts, ends)
+  mdast.children = starts.map((k, i) => [k, ends[i]])
+    // but filter out empty section
+    .filter(([start, end]) => start !== end)
+    // then return all nodes that are in between
+    .map(([start, end]) => {
+      // skip 'thematicBreak' nodes
+      const index = mdast.children[start].type === 'thematicBreak' ? start + 1 : start;
+      return {
+        type: 'section',
+        children: mdast.children.slice(index, end),
+      };
+    });
+}
+/* end: copied from helix-html-pipeline */
+
+export default function md2html(md, da = false) {
   // note: we could use the entire unified chain, but it would need to be async -
   // which would require too much of a change
   const mdast = unified()
@@ -28,6 +151,10 @@ export default function md2html(md) {
     .use(remarkGfm)
     .use(remarkGridTable)
     .parse(md);
+
+  if (da) {
+    split({ content: { mdast } });
+  }
 
   const hast = mdast2hast(mdast, {
     handlers: {
@@ -39,6 +166,10 @@ export default function md2html(md) {
 
   raw(hast);
   rehypeFormat()(hast);
+
+  if (da) {
+    createPageBlocks({ content: { hast } });
+  }
 
   return toHtml(hast, {
     upperDoctype: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,10 @@
         "@spectrum-web-components/icons-workflow": "1.6.0",
         "buffer": "6.0.3",
         "hast-util-raw": "9.1.0",
+        "hast-util-select": "6.0.4",
         "hast-util-to-html": "9.0.5",
+        "hast-util-to-string": "3.0.1",
+        "hastscript": "9.0.1",
         "jszip": "3.10.1",
         "mdast-util-to-hast": "13.2.0",
         "parcel": "2.15.2",
@@ -25,6 +28,7 @@
         "remark-gfm": "4.0.1",
         "remark-parse": "11.0.0",
         "unified": "11.0.5",
+        "unist-util-visit": "5.0.0",
         "ws": "8.18.2"
       },
       "devDependencies": {
@@ -6279,6 +6283,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "3.0.2",
       "dev": true,
@@ -7942,6 +7956,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "license": "MIT",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dirname-filename-esm": {
@@ -9985,6 +10012,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-from-parse5/node_modules/hastscript": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
+      "integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-has-property": {
       "version": "3.0.0",
       "license": "MIT",
@@ -10082,6 +10126,43 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-select": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
+      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^3.0.0",
+        "devlop": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-select/node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "license": "MIT",
@@ -10154,6 +10235,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-text": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
@@ -10182,18 +10276,30 @@
       }
     },
     "node_modules/hastscript": {
-      "version": "8.0.0",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
         "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^6.0.0",
+        "property-information": "^7.0.0",
         "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript/node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/he": {
@@ -21536,6 +21642,8 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "@spectrum-web-components/icons-workflow": "1.6.0",
     "buffer": "6.0.3",
     "hast-util-raw": "9.1.0",
+    "hast-util-select": "6.0.4",
     "hast-util-to-html": "9.0.5",
+    "hast-util-to-string": "3.0.1",
+    "hastscript": "9.0.1",
     "jszip": "3.10.1",
     "mdast-util-to-hast": "13.2.0",
     "parcel": "2.15.2",
@@ -33,6 +36,7 @@
     "remark-gfm": "4.0.1",
     "remark-parse": "11.0.0",
     "unified": "11.0.5",
+    "unist-util-visit": "5.0.0",
     "ws": "8.18.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix #537 

While DA html looks pretty straight forward, it still requires some adjustments, especially when not going through the UI (prosemirror reshapes the markup). This PR adds to operations (copied from the html-pipeline):

1. split sections (get rid of `<hr>` and create `div` nesting)
2. convert `<table>` structure into `<div>` structure