### PR TITLE
Convert all tables in HTML to DA-compliant div blocks

### DIFF
--- a/js/import/import.ui.js
+++ b/js/import/import.ui.js
@@ -22,6 +22,7 @@ import alert from '../shared/alert.js';
 import { toggleLoadingButton } from '../shared/ui.js';
 import { registerRuntime } from '../shared/runtime.js';
 import { applyDefaultTheme } from '../shared/theme.js';
+import { convertTablesToDA } from '../shared/da.js';
 import {
   setupPreview,
   attachPreviewListeners,
@@ -106,8 +107,16 @@ const postSuccessfulStep = async (results, originalURL) => {
         files.push({ type: 'md', filename: `${path}.md`, data: md });
       }
 
+      // if we were told to save the DA file, add it to the list
       if (config.fields['import-local-da'] && md) {
-        files.push({ type: 'da', filename: `${path}.html`, data: `<html><head></head><body><main>${WebImporter.md2html(md)}</main></body></html>` });
+        // Convert markdown to HTML, then to DA blocks, then flatten
+        const html = WebImporter.md2html(md);
+        const daHtml = convertTablesToDA(html);
+        files.push({ 
+          type: 'da', 
+          filename: `${path}.html`, 
+          data: `<body><main><div>${daHtml}</div></main></body>` 
+        });
       }
 
       // if we were told to save the JCR package, add it to the list

--- a/js/shared/da.js
+++ b/js/shared/da.js
@@ -8,7 +8,7 @@
 export function convertTablesToDA(html) {
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, 'text/html');
-    const tables = doc.querySelectorAll('table');
+    const tables = doc.querySelectorAll('table:not(table table)');
     if (!tables.length) return doc.body.innerHTML;
   
     tables.forEach(table => {

--- a/js/shared/da.js
+++ b/js/shared/da.js
@@ -12,12 +12,11 @@ export function convertTablesToDA(html) {
     if (!tables.length) return doc.body.innerHTML;
   
     tables.forEach(table => {
-      // Get block name from first th or td in the first row
+      // Get block name from first row
       let blockName = '';
       const firstRow = table.rows[0];
       if (firstRow) {
-        const firstCell = firstRow.cells[0];
-        if (firstCell) blockName = firstCell.textContent.trim().toLowerCase();
+        blockName = firstRow.textContent.trim().toLowerCase();
       }
       if (!blockName) return;
   
@@ -28,11 +27,7 @@ export function convertTablesToDA(html) {
       // Convert each row to a div, skipping the first row if it's the block name
       Array.from(table.rows).forEach((row, idx) => {
         // Skip first row if it's a single cell with the block name
-        if (
-          idx === 0 &&
-          row.cells.length === 1 &&
-          row.cells[0].textContent.trim().toLowerCase() === blockName
-        ) {
+        if (idx === 0) {
           return;
         }
         const rowDiv = doc.createElement('div');

--- a/js/shared/da.js
+++ b/js/shared/da.js
@@ -1,0 +1,52 @@
+/**
+ * Converts all tables in HTML to DA-compliant div blocks.
+ * Each table is replaced by a <div class="blockname">, where blockname is the first th or td text (lowercased).
+ * Each table row becomes a <div>, and each cell is wrapped in a <div><p>...</p></div>.
+ * @param {string} html The HTML string
+ * @returns {string} The transformed HTML string with DA blocks
+ */
+export function convertTablesToDA(html) {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const tables = doc.querySelectorAll('table');
+    if (!tables.length) return doc.body.innerHTML;
+  
+    tables.forEach(table => {
+      // Get block name from first th or td in the first row
+      let blockName = '';
+      const firstRow = table.rows[0];
+      if (firstRow) {
+        const firstCell = firstRow.cells[0];
+        if (firstCell) blockName = firstCell.textContent.trim().toLowerCase();
+      }
+      if (!blockName) return;
+  
+      // Create DA block div
+      const blockDiv = doc.createElement('div');
+      blockDiv.className = blockName;
+  
+      // Convert each row to a div, skipping the first row if it's the block name
+      Array.from(table.rows).forEach((row, idx) => {
+        // Skip first row if it's a single cell with the block name
+        if (
+          idx === 0 &&
+          row.cells.length === 1 &&
+          row.cells[0].textContent.trim().toLowerCase() === blockName
+        ) {
+          return;
+        }
+        const rowDiv = doc.createElement('div');
+        Array.from(row.cells).forEach(cell => {
+          const cellDiv = doc.createElement('div');
+          cellDiv.innerHTML = `<p>${cell.innerHTML}</p>`;
+          rowDiv.appendChild(cellDiv);
+        });
+        blockDiv.appendChild(rowDiv);
+      });
+  
+      table.replaceWith(blockDiv);
+    });
+  
+    return doc.body.innerHTML;
+  }
+  


### PR DESCRIPTION
## Description

 * Converts all tables in HTML to DA-compliant div blocks.
 * Each table is replaced by a `<div class="blockname">`, where blockname is the first th or td text (lowercased).
 * Each table row becomes a `<div>`, and each cell is wrapped in a `<div><p>...</p></div>`

## Related Issue

#537 

## Motivation and Context

Issue while importing content from customer site into DA, blank pages due to non-compliant structure in DA docs.


## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
