### PR TITLE
build: pin packageManager to npm@10.8.2 to stop Renovate lockfile drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "helix-importer-ui",
   "version": "1.57.17",
   "type": "module",
+  "packageManager": "npm@10.8.2",
   "scripts": {
     "test": "c8 mocha",
     "clean": "rm -fr ./js/dist",


### PR DESCRIPTION
## Problem

CI runs Node 20 → **npm 10.8.2**, which requires the nested `chokidar@3.6.0` tree (`chokidar` → `glob-parent@5.1.2` → `readdirp@3.6.0`) under `semantic-release-discord-bot` in `package-lock.json`. Renovate regenerates the lockfile with a **newer npm** that drops that tree, so every Renovate PR — and every rebase — breaks `npm ci`:

```
npm error Missing: chokidar@3.6.0 from lock file
```

This hit #585 and #586; the one-off lockfile resync (#589) fixed `main` but Renovate re-broke each branch on rebase. Verified the disagreement is npm-version-driven: npm 10.x → 3 nested entries (what CI wants), npm 11 → 2, Renovate → 0.

## Fix

Pin `"packageManager": "npm@10.8.2"` in `package.json`. Renovate honors this (via Corepack) and regenerates lockfiles with the same npm as CI, keeping `package-lock.json` in sync going forward. The lockfile itself is unchanged — `main` already matches npm 10.8.2's output. Verified `npm ci` passes with npm 10.8.2.

After merge, rebase #585 / #586 (or let Renovate rebase) and they'll stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
